### PR TITLE
Fixed versions in the nodecg.json files to larger than instead of ^

### DIFF
--- a/gxl-credits/nodecg.json
+++ b/gxl-credits/nodecg.json
@@ -1,7 +1,7 @@
 {
   "name": "gxl-credits",
   "version": "0.0.1",
-  "nodecgDependency": "^0.3.0",
+  "nodecgDependency": ">=0.3.0",
   "homepage": "",
   "authors": [],
   "description": "",

--- a/toth-alert/nodecg.json
+++ b/toth-alert/nodecg.json
@@ -1,7 +1,7 @@
 {
   "name": "toth-alert",
   "version": "0.0.1",
-  "nodecgDependency": "^0.3.0",
+  "nodecgDependency": ">=0.3.0",
   "homepage": "http://tipofthehats.org/",
   "authors": [
     "Alex Van Camp <email@alexvan.camp>",

--- a/toth-lowerthird/nodecg.json
+++ b/toth-lowerthird/nodecg.json
@@ -1,7 +1,7 @@
 {
   "name": "toth-lowerthird",
   "version": "0.0.1",
-  "nodecgDependency": "^0.3.0",
+  "nodecgDependency": ">=0.3.0",
   "homepage": "http://tipofthehats.org/",
   "authors": [
     "Alex Van Camp <email@alexvan.camp>",

--- a/toth-socialmedia/nodecg.json
+++ b/toth-socialmedia/nodecg.json
@@ -1,7 +1,7 @@
 {
   "name": "toth-socialmedia",
   "version": "0.0.1",
-  "nodecgDependency": "^0.3.0",
+  "nodecgDependency": ">=0.3.0",
   "homepage": "http://tipofthehats.org/",
   "authors": [
     "Alex Van Camp <email@alexvan.camp>",


### PR DESCRIPTION
It works fine on the newer versions so for testing/ease of use purposes i suggest that it's Larger then >= instead of ^ to 0.3.0, now the demos also work in 0.4.4.